### PR TITLE
Fix review feedback from PR #131:

### DIFF
--- a/.agents/skills/csharp-docs-wiki/SKILL.md
+++ b/.agents/skills/csharp-docs-wiki/SKILL.md
@@ -19,7 +19,7 @@ To use this skill, ensure your `.csproj` enables XML documentation generation:
 </PropertyGroup>
 ```
 
-After building the project, the XML documentation file will appear under `bin/` (for example: `bin/Debug/net8.0/MyProject.xml`).
+After building the project, the XML documentation file will appear under `bin/` (for example: `bin/Debug/net10.0/MyProject.xml`).
 
 ## When to use this skill
 
@@ -50,13 +50,13 @@ When invoked, the agent should:
 5. Collect the resulting XML documentation files from `bin/Debug/net10.0/`
 6. Pass all XML files to the tool:
 
-```
+```bash
 dotnet run --file .agents/skills/csharp-docs-wiki/XmlDocsToWiki.cs -- bin/Debug/net10.0/Project1.xml bin/Debug/net10.0/Project2.xml
 ```
 
 ### Usage
 
-```
+```text
 dotnet run --file .agents/skills/csharp-docs-wiki/XmlDocsToWiki.cs -- <xml-file> [xml-file2 ...] [output-path]
 ```
 

--- a/.agents/skills/csharp-docs-wiki/SKILL.md
+++ b/.agents/skills/csharp-docs-wiki/SKILL.md
@@ -56,7 +56,7 @@ dotnet run --file .agents/skills/csharp-docs-wiki/XmlDocsToWiki.cs -- bin/Debug/
 
 ### Usage
 
-```text
+```bash
 dotnet run --file .agents/skills/csharp-docs-wiki/XmlDocsToWiki.cs -- <xml-file> [xml-file2 ...] [output-path]
 ```
 

--- a/.agents/skills/csharp-docs-wiki/XmlDocsToWiki.cs
+++ b/.agents/skills/csharp-docs-wiki/XmlDocsToWiki.cs
@@ -24,10 +24,19 @@ var outputPath = "./docs";
 
 for (int i = 0; i < args.Length; i++)
 {
-    if (File.Exists(args[i]) || args[i].EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
+    var looksLikeXml = File.Exists(args[i]) || args[i].EndsWith(".xml", StringComparison.OrdinalIgnoreCase);
+    if (looksLikeXml)
+    {
         xmlPaths.Add(args[i]);
-    else
+    }
+    else if (i == args.Length - 1)
+    {
         outputPath = args[i];
+    }
+    else
+    {
+        Console.WriteLine($"Warning: ignoring unrecognized argument '{args[i]}' (not an existing/.xml file, and not the last argument).");
+    }
 }
 
 var templatesDir = FindTemplates(null)
@@ -368,7 +377,7 @@ class Template
         if (val is List<Dictionary<string, object?>> list) return list;
         if (val is List<Dictionary<string, string>> stringDicts)
             return stringDicts.Select(s => s.ToDictionary(kv => kv.Key, kv => (object?)kv.Value)).ToList();
-        if (val is List<string> strings) return strings.Select(s => new Dictionary<string, object?> { ["."] = s }).ToList();
+        if (val is List<string> strings) return strings.Select(s => new Dictionary<string, object?> { ["Value"] = s }).ToList();
         return new();
     }
 }
@@ -427,7 +436,7 @@ class XmlDocParser
                 typeName = beforeParams.Substring(secondLastDot + 1, lastDot - secondLastDot - 1);
             }
 
-            if (ns.StartsWith("System")) continue;
+            if (ns == "System" || ns.StartsWith("System.")) continue;
 
             var displayTypeName = Regex.Replace(typeName, @"`(\d+)", "_$1");
             var nestedDot = typeName.IndexOf('.');

--- a/.agents/skills/csharp-docs-wiki/templates/member.md
+++ b/.agents/skills/csharp-docs-wiki/templates/member.md
@@ -31,5 +31,5 @@
 **Remarks:** {Remarks}
 
 {#each SeeAlso}
-- See: **{.}**
+- See: **{Value}**
 {/each}


### PR DESCRIPTION
- Fix SeeAlso template: use {Value} instead of {.} which template engine cannot match
- Update GetListValue to expose string list items under 'Value' key
- Add language tags (bash/text) to fenced code blocks in SKILL.md markdownlint warnings
- Fix net8.0 -> net10.0 inconsistency in overview example path
- Tighten System namespace filter: 'System.' prefix instead of 'System'